### PR TITLE
Use change event for select persistence

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -126,7 +126,8 @@ document.addEventListener('DOMContentLoaded', () => {
         el.value = saved;
       }
     }
-    el.addEventListener('input', () => {
+    const evt = el.tagName === 'SELECT' ? 'change' : 'input';
+    el.addEventListener(evt, () => {
       const val = el.type === 'checkbox' ? el.checked : el.value;
       setStored('vb_' + el.id, val);
     });


### PR DESCRIPTION
## Summary
- ensure form <select> elements use change events when saving to localStorage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892235a7ce083268054ab14a1e363bf