### PR TITLE
Persist language selection and initialize form storage

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -86,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   let currentLang = getStored('vb_language') || 'FR';
+  setStored('vb_language', currentLang);
   const languageSelect = document.getElementById('languageSelect');
   languageSelect.value = currentLang;
 
@@ -125,6 +126,9 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         el.value = saved;
       }
+    } else {
+      const initial = el.type === 'checkbox' ? el.checked : el.value;
+      setStored('vb_' + el.id, initial);
     }
     el.addEventListener('input', () => {
       const val = el.type === 'checkbox' ? el.checked : el.value;


### PR DESCRIPTION
## Summary
- ensure chosen language is persisted to localStorage on load
- seed localStorage with initial form values if no saved data exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68922357cef48326abe9a2ab64e7a126