### PR TITLE
Handle both input and change events for form persistence

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -130,11 +130,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const initial = el.type === 'checkbox' ? el.checked : el.value;
       setStored('vb_' + el.id, initial);
     }
-    const evt = el.tagName === 'SELECT' ? 'change' : 'input';
-    el.addEventListener(evt, () => {
-      const val = el.type === 'checkbox' ? el.checked : el.value;
-      setStored('vb_' + el.id, val);
-    });
+    ['input', 'change'].forEach(evt =>
+      el.addEventListener(evt, () => {
+        const val = el.type === 'checkbox' ? el.checked : el.value;
+        setStored('vb_' + el.id, val);
+      })
+    );
   });
 
   document.getElementById('reset-btn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- persist form inputs when either `input` or `change` events fire to capture edits, blurs, and autofill.

## Testing
- `python -m pytest`
- Node script simulating input and change events to verify local storage updates
- ⚠️ Unable to run browser devtools; attempted to install `jsdom` for headless testing but encountered a 403 error

------
https://chatgpt.com/codex/tasks/task_e_689229505fbc8326ba57a4912a0aaa89