### PR TITLE
Add version number to application title

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -9,8 +9,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   /* --- Translation dictionary --- */
   const translations = {
-    app_title: { FR: 'Viscobat - Application de viscosité', EN: 'Viscobat - Fluid Viscosity App' },
-    app_name: { FR: 'Viscobat - Application de viscosité', EN: 'Viscobat - Fluid Viscosity App' },
+    app_title: { FR: 'Viscobat v2.0 - Application de viscosité', EN: 'Viscobat v2.0 - Fluid Viscosity App' },
+    app_name: { FR: 'Viscobat v2.0 - Application de viscosité', EN: 'Viscobat v2.0 - Fluid Viscosity App' },
     tab_vi: { FR: 'Indice de viscosité', EN: 'Viscosity Index' },
     tab_temp: { FR: 'Viscosité vs Température', EN: 'Viscosity vs Temperature' },
     tab_mixture: { FR: 'Mélange', EN: 'Mixture' },

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title data-i18n="app_title">Viscobat - Application de viscosité</title>
+  <title data-i18n="app_title">Viscobat v2.0 - Application de viscosité</title>
   <!-- Favicon and application icon -->
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='icon.png') }}">
   <!-- Custom stylesheet -->
@@ -13,7 +13,7 @@
   <header class="app-header">
     <div class="logo-container">
       <img src="{{ url_for('static', filename='icon.png') }}" alt="Logo" class="logo">
-      <span class="app-title" data-i18n="app_name">Viscobat - Application de viscosité</span>
+      <span class="app-title" data-i18n="app_name">Viscobat v2.0 - Application de viscosité</span>
     </div>
     <div class="header-controls">
       <div class="lang-select">


### PR DESCRIPTION
## Summary
- show version v2.0 alongside application title in HTML header and page title
- update translation strings so page and header titles include version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68931b7f5d448326a0319a888fa7fc4c