### PR TITLE
feat: add motul logo to header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,6 +43,10 @@ body {
   gap: 0.5rem;
 }
 
+.motul-logo {
+  height: 32px;
+}
+
 .lang-select select {
   padding: 0.25rem;
   font-size: 1rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
         </select>
       </div>
       <button id="reset-btn" class="secondary-btn" data-i18n="btn_refresh">Rafraîchir</button>
+      <img src="{{ url_for('static', filename='Motul_logo.png') }}" alt="Motul" class="motul-logo">
     </div>
   </header>
   <nav class="tab-bar">


### PR DESCRIPTION
## Summary
- show the Motul logo next to the refresh control in the header
- style the logo for consistent sizing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689324762b90832685c93aa4f9a2bb34