### PR TITLE
Preserve language preference on reset

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -158,7 +158,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('input, select').forEach(registerPersistent);
 
   document.getElementById('reset-btn').addEventListener('click', () => {
+    const savedLang = getStored('vb_language') || currentLang;
     clearPrefixedStorage('vb_');
+    setStored('vb_language', savedLang);
     window.location.reload();
   });
 


### PR DESCRIPTION
## Summary
- avoid clearing saved language when using the Reset button

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_689348546e448326aec6a3d4b15f2469