### PR TITLE
fix: adjust solver mixture viscosity label

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -46,6 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
     solver_min: { FR: 'Minimiser', EN: 'Minimise' },
     solver_max: { FR: 'Maximiser', EN: 'Maximise' },
     solver_set: { FR: 'Fixer une valeur', EN: 'Set value' },
+    solver_mix_value: { FR: 'Viscosité (mm²/s)', EN: 'Viscosity (mm²/s)' },
     solver_min_value: { FR: 'Min', EN: 'Min' },
     solver_max_value: { FR: 'Max', EN: 'Max' },
     btn_solve: { FR: 'Résoudre', EN: 'Solve' },

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,7 +201,7 @@
             </select>
           </div>
           <div class="form-row" id="mix-value-row" style="display:none;">
-            <label for="mix-value" data-i18n="solver_value">Valeur</label>
+            <label for="mix-value" data-i18n="solver_mix_value">Viscosité (mm²/s)</label>
             <input type="number" step="any" id="mix-value">
           </div>
           <div class="form-row" id="mix-range-row" style="display:none;">


### PR DESCRIPTION
## Summary
- correct mixture solver set value label to show viscosity instead of percent mass
- add translations for viscosity label in solver

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ffb03f38832692361248b8d33257