### PR TITLE
Remove redundant headings from temperature property subtabs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -105,7 +105,6 @@
       </div>
 
       <section id="subtab-kv" class="sub-tab-content active">
-        <h3 data-i18n="kv_heading">KV (cSt)</h3>
         <form id="tempForm" class="form-grid">
           <div class="form-row full-row">
             <div class="table-wrapper">
@@ -148,7 +147,6 @@
       </section>
 
       <section id="subtab-density" class="sub-tab-content">
-        <h3 data-i18n="density_heading">Density (kg/m³)</h3>
         <form id="densityForm" class="form-grid">
           <div class="form-row full-row">
             <div class="table-wrapper">
@@ -191,7 +189,6 @@
       </section>
 
       <section id="subtab-cp" class="sub-tab-content">
-        <h3 data-i18n="cp_heading">Cp (kJ/kgK)</h3>
         <form id="cpForm" class="form-grid">
           <div class="form-row full-row">
             <div class="table-wrapper">
@@ -233,7 +230,6 @@
       </section>
 
       <section id="subtab-thermal" class="sub-tab-content">
-        <h3 data-i18n="thermal_heading">Thermal conductivity (W/mK)</h3>
         <form id="thermalForm" class="form-grid">
           <div class="form-row full-row">
             <div class="table-wrapper">


### PR DESCRIPTION
## Summary
- remove redundant property headings from each temperature extrapolation subtab to rely on highlighted tab labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db19738048326856422f489dc2042)